### PR TITLE
Agregando nuevas funcionalidades

### DIFF
--- a/.gitchangelog.rc
+++ b/.gitchangelog.rc
@@ -193,9 +193,9 @@ shell=False)
 ##        Examples:
 ##           - makotemplate("restructuredtext")
 ##
-output_engine = rest_py
+#output_engine = rest_py
 #output_engine = mustache("restructuredtext")
-#output_engine = mustache("markdown")
+output_engine = mustache("markdown")
 #output_engine = makotemplate("restructuredtext")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Mako==1.1.0
+MarkupSafe==1.1.1
+numpy==1.17.4
+pystache==0.5.4

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1183,8 +1183,10 @@ class GitRepos(object):
         No firm reason for that, and it could change in future version.
 
         """
+
         if contains:
             tags = self.git.tag(contains=contains).split("\n")
+
         else:
             tags = self.git.tag().split("\n")
         ## Should we use new version name sorting ?  refering to :
@@ -1193,6 +1195,7 @@ class GitRepos(object):
         ## git version <2.0
         return sorted([self.commit(tag) for tag in tags if tag != ''],
                       key=lambda x: int(x.committer_date_timestamp))
+
 
     def log(self, includes=["HEAD", ], excludes=[], include_merge=True,
             encoding=_preferred_encoding):
@@ -1513,6 +1516,7 @@ def FileRegexSubst(filename, pattern, replace, flags=0):
 ## Data Structure
 ##
 
+
 def versions_data_iter(repository, revlist=None,
                        ignore_regexps=[],
                        section_regexps=[(None, '')],
@@ -1565,14 +1569,23 @@ def versions_data_iter(repository, revlist=None,
 
     tags.append(repository.commit("HEAD"))
 
+    ## Variable that will save the requested tags.
+    var_to_show = []
+
     if revlist:
         max_rev = repository.commit(revs[0])
         new_tags = []
+
+        var_to_show = revlist[0].split('..')
+        show_tags(var_to_show)
+
         for tag in tags:
             new_tags.append(tag)
+
             if max_rev <= tag:
                 break
         tags = new_tags
+
     else:
         max_rev = tags[-1]
 
@@ -1591,6 +1604,7 @@ def versions_data_iter(repository, revlist=None,
             "tag": tag.identifier if tag.identifier != "HEAD" else None,
             "commit": tag,
             "solicited_commits": get_revs(revs),
+            "solicited_tags": show_tags(var_to_show),
         }
 
         sections = collections.defaultdict(list)
@@ -1628,6 +1642,22 @@ def versions_data_iter(repository, revlist=None,
             yield current_version
         versions_done[tag] = current_version
 
+## Method implementation that allows to see the requested tags
+def show_tags(var_to_show):
+    try:
+
+        if len(var_to_show) == 2:
+            first_tag = var_to_show[0]
+            second_tag = var_to_show[1]
+
+            return "From tag  %s to tag %s." % (first_tag, second_tag)
+
+        else:
+            return "No tags requested..."
+
+    except ValueError:
+        return None
+
 ## Method that gets the id's solicited by users and return the information on the screen.
 def get_revs(revs):
     try:
@@ -1640,6 +1670,7 @@ def get_revs(revs):
 
         else:
             return "Request for all commits made."
+
     except ValueError:
         return None
 

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1727,14 +1727,16 @@ def get_url(repository, commit):
     try:
         id = commit.sha1_short
         url = repository.git.config('remote.origin.url')
+
         if url:
             new_url = url[:-4]
-            p_url = url[4:]
+            p_url = url[:4]
+
             if p_url == "git@":
-                del[p_url]
                 url_r = url.replace(":", "/")
+                this_r = url_r[4:]
                 p_url = "https://"
-                final_url_g = p_url + url_r + "/commit/" + id
+                final_url_g = p_url + this_r + "commit/" + id
                 return final_url_g
 
             else:

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -230,9 +230,7 @@ if WIN32 and not PY3:
 usage_msg = """
   %(exname)s {-h|--help}
   %(exname)s {-v|--version}
-  %(exname)s [--debug|-d] [REVLIST]
-  %(exname)s {-u|--url}"""
-
+  %(exname)s [--debug|-d] [REVLIST]"""
 
 description_msg = """\
 Run this command in a git repository to output a formatted changelog
@@ -1731,8 +1729,18 @@ def get_url(repository, commit):
         url = repository.git.config('remote.origin.url')
         if url:
             new_url = url[:-4]
-            final_url = new_url + "/commit/" + id
-            return final_url
+            p_url = url[4:]
+            if p_url == "git@":
+                del[p_url]
+                url_r = url.replace(":", "/")
+                p_url = "https://"
+                final_url_g = p_url + url_r + "/commit/" + id
+                return final_url_g
+
+            else:
+                final_url = new_url + "/commit/" + id
+                return final_url
+
         else:
             return url
 

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1558,6 +1558,8 @@ def versions_data_iter(repository, revlist=None,
                 if rev.startswith("^")] if revlist else []
 
     revs = repository.git.rev_list(*revlist).split("\n") if revlist else []
+
+
     revs = [rev for rev in revs if rev != ""]
 
     if revlist and not revs:
@@ -1642,6 +1644,25 @@ def get_url(repository, commit):
             return final_url
         else:
             return url
+
+    except ValueError:
+        return None
+
+def revs_range(*revlist):
+    revs = []
+    try:
+        print("************************************************************")
+        print("************************************************************")
+        print("**                REPORTS BY RANK                         **")
+        print("************************************************************")
+        print("************************************************************")
+        first_commit = str(input("**  Enter the first ID to evaluate: "))
+        revs.append(first_commit)
+        second_commit = str(input("**  Enter the second ID to evaluate: "))
+        revs.append(second_commit)
+        print("************************************************************")
+        print("************************************************************")
+        return revs
 
     except ValueError:
         return None

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1691,11 +1691,11 @@ def r_send(commit):
     first_split = commit_split_a(general_split)
     second_split = commit_split_b(first_split)
 
-    if second_split[0] == "NONE" or second_split[0] == "MERGE":
-        condition_i = False
+    if re.search(r"^[A-Za-z].*[\d]+$", second_split[0]):
+        condition_i = True
 
     else:
-        condition_i = True
+        condition_i = False
 
     s_dictionary = {
         "first_s": first_split[0],
@@ -1729,7 +1729,6 @@ def get_url(repository, commit):
         url = repository.git.config('remote.origin.url')
 
         if url:
-            new_url = url[:-4]
             p_url = url[:4]
 
             if p_url == "git@":
@@ -1741,6 +1740,7 @@ def get_url(repository, commit):
                 return final_url_g
 
             else:
+                new_url = url[:-4]
                 final_url = new_url + "/commit/" + id
                 return final_url
 

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -144,6 +144,7 @@ if WIN32 and not PY3:
     ## Patched functions/classes
     ##
 
+
     def CreateProcess(executable, args, _p_attr, _t_attr,
                       inherit_handles, creation_flags, env, cwd,
                       startup_info):
@@ -1742,7 +1743,7 @@ def find_replace(second_split, jira_url):
         u"{{#render}}[{{{.}}}]({{#link}}{{.}}{{/link}}/{{{.}}}){{/render}}")
 
     to_render = renderer.render(parsed, {
-        'render': r'\1 ',
+        'render': r'\1',
         'link': jira_url
     })
     to_change = re.sub(r'([A-Z]+-[\d]+)', to_render, complement)
@@ -1774,7 +1775,6 @@ def r_send(commit, jira_url):
 ## Method implementation that allows users to see requests (tags or commits)
 def see_requests(var_to_show):
     try:
-
         if len(var_to_show) == 2:
             first_ = var_to_show[0]
             second_ = var_to_show[1]

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1573,10 +1573,7 @@ def versions_data_iter(repository, revlist=None,
     if revlist:
         max_rev = repository.commit(revs[0])
         new_tags = []
-
         var_to_show = revlist[0].split('..')
-        see_requests(var_to_show)
-
         for tag in tags:
             new_tags.append(tag)
             if max_rev <= tag:

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1641,6 +1641,50 @@ def versions_data_iter(repository, revlist=None,
             yield current_version
         versions_done[tag] = current_version
 
+
+## Dividing commits
+def commit_split_a(commit):
+    general_split = (commit.subject)
+    to_string = list(general_split)
+    this_list = []
+    new_list = []
+    for i in general_split:
+        this_list.append(i)
+        to_string.remove(i)
+        string = "".join(to_string)
+
+        if i == ":":
+            new_list.append(string)  ## Removing first []
+            break
+
+    commit_split_b("".join(new_list))
+    return "".join(this_list)  ## It should return SGI:...
+
+
+def commit_split_b(new_list):
+    n_spaces = new_list.lstrip()
+    to_split = n_spaces.split(" ")
+
+    the_identifier = str(to_split[0])
+
+    del(to_split[0])
+    final_s = " ".join(to_split)
+    split_final(final_s)
+    return the_identifier  ## It should return NONE-ANTA...
+
+def split_final(final_s):
+    return final_s ## It should return the rest of the necessary commit
+
+def r_send(this_list, the_identifier, final_s):
+    s_dictionary = {
+        "first_s": commit_split_a(this_list),
+        "s_identifier": commit_split_b(the_identifier),
+        "complement": split_final(final_s),
+    }
+
+    return s_dictionary
+
+
 ## Method implementation that allows users to see requests (tags or commits)
 def see_requests(var_to_show):
     try:

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -926,7 +926,7 @@ class GitCommit(SubGitObjectMixin):
     def date(self):
         d = datetime.datetime.utcfromtimestamp(
             float(self.author_date_timestamp))
-        return d.strftime('%Y-%m-%d')
+        return d.strftime('%d-%m-%Y')
 
     @property
     def has_annotated_tag(self):
@@ -1617,7 +1617,7 @@ def versions_data_iter(repository, revlist=None,
             sections[matched_section].append({
                 ## Add the id and date to use in the code output.
                 "id": commit.sha1_short,
-                "date": commit.author_date,
+                "date": commit.date,
                 "author": commit.author_name,
                 "authors": commit.authors,
                 "subject": subject_process(commit.subject),

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1644,25 +1644,29 @@ def versions_data_iter(repository, revlist=None,
             ## Finally storing the commit in the matching section
 
             if clean:
+                result = bool
                 for value in clean:
-                    #this_f = re.findall(value, commit_f)
                     if value in commit_f:
-                        continue
+                        result = True
 
                     else:
-                        sections[matched_section].append({
-                            "id": commit.sha1_short,
-                            "date": commit.date,
-                            "author": commit.author_name,
-                            "authors": commit.authors,
-                            "body": body_process(commit.body),
-                            "shortRemote": get_url(repository, commit),
-                            "first_parameter": t_split["first_s"],
-                            "second_parameter": t_split["s_identifier"],
-                            "third_parameter": t_split["complement"],
-                            "condition_i": t_split["condition_i"],
-                            "jira_url": jira_url,
-                        })
+                        result = False
+
+                if result is False:
+                    sections[matched_section].append({
+                        ## Add the id and date to use in the code output.
+                        "id": commit.sha1_short,
+                        "date": commit.date,
+                        "author": commit.author_name,
+                        "authors": commit.authors,
+                        "body": body_process(commit.body),
+                        "shortRemote": get_url(repository, commit),
+                        "first_parameter": t_split["first_s"],
+                        "second_parameter": t_split["s_identifier"],
+                        "third_parameter": t_split["complement"],
+                        "condition_i": t_split["condition_i"],
+                        "jira_url": jira_url,
+                    })
 
             else:
                 sections[matched_section].append({

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -230,7 +230,9 @@ if WIN32 and not PY3:
 usage_msg = """
   %(exname)s {-h|--help}
   %(exname)s {-v|--version}
-  %(exname)s [--debug|-d] [REVLIST]"""
+  %(exname)s [--debug|-d] [REVLIST]
+  %(exname)s {-u|--url}"""
+
 
 description_msg = """\
 Run this command in a git repository to output a formatted changelog
@@ -1630,7 +1632,7 @@ def versions_data_iter(repository, revlist=None,
                 "date": commit.date,
                 "author": commit.author_name,
                 "authors": commit.authors,
-                "subject": subject_process(commit.subject),
+                ## "subject": subject_process(commit.subject),
                 "body": body_process(commit.body),
                 "shortRemote": get_url(repository, commit),
                 "first_parameter": t_split["first_s"],
@@ -1675,7 +1677,7 @@ def commit_split_b(first_split):
 
     the_identifier = str(to_split[0])
 
-    del (to_split[0])
+    del(to_split[0])
     final_s = " ".join(to_split)
 
     '''if the_identifier == "NONE":
@@ -1761,7 +1763,8 @@ def changelog(output_engine=rest_py,
     }
 
     ## Setting main container of changelog elements
-    title = None if kwargs.get("revlist") else "Changelog"
+    ## title = None if kwargs.get("revlist") else "Changelog"
+    title = "Changelog"
     data = {"title": title,
             "versions": []}
 
@@ -1847,6 +1850,8 @@ def parse_cmd_line(usage, description, epilog, exname, version):
                         help="Enable debug mode (show full tracebacks).",
                         action="store_true", dest="debug")
     parser.add_argument('revlist', nargs='*', action="store", default=[])
+
+    ##parser.add_argument('-u', '--url', nargs="*", action="")
 
     ## Remove "show" as first argument for compatibility reason.
 

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -233,7 +233,8 @@ usage_msg = """
   %(exname)s {-h|--help}
   %(exname)s {-v|--version}
   %(exname)s [--debug|-d] [REVLIST]
-  %(exname)s {-c|--clean}"""
+  %(exname)s {-c|--clean}
+  %(exname)s {-t|--title}"""
 
 description_msg = """\
 Run this command in a git repository to output a formatted changelog
@@ -1541,6 +1542,7 @@ def versions_data_iter(repository, revlist=None,
                        warn=warn,        ## Mostly used for test
                        jira_url="",
                        clean=None,
+                       title=""
                        ):
     """Returns an iterator through versions data structures
 
@@ -1825,7 +1827,21 @@ def get_parameters(opts):
         return None
 
 
-def changelog(output_engine=rest_py,
+## Title parameters
+def change_title(opts):
+    try:
+        if opts.title:
+            new_title = opts.title
+            return " ".join(new_title)
+
+        else:
+            return "Changelog"
+
+    except TypeError:
+        return "Changelog"
+
+
+def changelog(title, output_engine=rest_py,
               unreleased_version_label="unreleased",
               warn=warn,        ## Mostly used for test
               **kwargs):
@@ -1853,7 +1869,8 @@ def changelog(output_engine=rest_py,
 
     ## Setting main container of changelog elements
     ## title = None if kwargs.get("revlist") else "Changelog"
-    title = "Changelog"
+
+    title = title
     data = {"title": title,
             "versions": []}
 
@@ -1943,6 +1960,9 @@ def parse_cmd_line(usage, description, epilog, exname, version):
 
     parser.add_argument('-c', '--clean', nargs="*", help="Requires "
                         "keywords (Ex. -c Item)", action="store")
+
+    parser.add_argument('-t', '--title', nargs="*", help="To change of "
+                        "changelog title.", action="store")
 
     ## Remove "show" as first argument for compatibility reason.
 
@@ -2165,13 +2185,14 @@ def main():
     log_encoding = get_log_encoding(repository, config)
     revlist = get_revision(repository, config, opts)
     clean = get_parameters(opts)
+    title = change_title(opts)
     config['unreleased_version_label'] = eval_if_callable(
         config['unreleased_version_label'])
     manage_obsolete_options(config)
 
     try:
         content = changelog(
-            repository=repository, revlist=revlist, clean=clean,
+            repository=repository, revlist=revlist, clean=clean, title=title,
             ignore_regexps=config['ignore_regexps'],
             section_regexps=config['section_regexps'],
             unreleased_version_label=config['unreleased_version_label'],

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1593,6 +1593,7 @@ def versions_data_iter(repository, revlist=None,
 
     tags = list(reversed(tags))
 
+
     ## Get the changes between tags (releases)
     for idx, tag in enumerate(tags):
 
@@ -1619,6 +1620,7 @@ def versions_data_iter(repository, revlist=None,
                 continue
 
             matched_section = first_matching(section_regexps, commit.subject)
+            t_split = r_send(commit)
 
             ## Finally storing the commit in the matching section
 
@@ -1631,6 +1633,9 @@ def versions_data_iter(repository, revlist=None,
                 "subject": subject_process(commit.subject),
                 "body": body_process(commit.body),
                 "shortRemote": get_url(repository, commit),
+                "first_parameter": t_split["first_s"],
+                "second_parameter": t_split["s_identifier"],
+                "third_parameter": t_split["complement"],
             })
 
         ## Flush current version
@@ -1641,10 +1646,9 @@ def versions_data_iter(repository, revlist=None,
             yield current_version
         versions_done[tag] = current_version
 
-
 ## Dividing commits
-def commit_split_a(commit):
-    general_split = (commit.subject)
+def commit_split_a(general_split):
+    t_split = []
     to_string = list(general_split)
     this_list = []
     new_list = []
@@ -1657,33 +1661,45 @@ def commit_split_a(commit):
             new_list.append(string)  ## Removing first []
             break
 
-    commit_split_b("".join(new_list))
-    return "".join(this_list)  ## It should return SGI:...
+    second_split = "".join(new_list)
+    first_split = "".join(this_list)
+    t_split.append(first_split)
+    t_split.append(second_split)
+    return t_split  ## It should return SGI:...
 
-
-def commit_split_b(new_list):
-    n_spaces = new_list.lstrip()
+def commit_split_b(first_split):
+    second_split = first_split[1]
+    third_split = []
+    n_spaces = second_split.lstrip()
     to_split = n_spaces.split(" ")
 
     the_identifier = str(to_split[0])
 
-    del(to_split[0])
+    del (to_split[0])
     final_s = " ".join(to_split)
-    split_final(final_s)
-    return the_identifier  ## It should return NONE-ANTA...
 
-def split_final(final_s):
-    return final_s ## It should return the rest of the necessary commit
+    '''if the_identifier == "NONE":
+        return the_identifier  ## It should return NONE
 
-def r_send(this_list, the_identifier, final_s):
+    else:
+        return the_identifier  ## It should return url + ANTA...'''
+
+    third_split.append(the_identifier)
+    third_split.append(final_s)
+
+    return third_split
+
+def r_send(commit):
+    general_split = (commit.subject)
+    first_split = commit_split_a(general_split)
+    second_split = commit_split_b(first_split)
+
     s_dictionary = {
-        "first_s": commit_split_a(this_list),
-        "s_identifier": commit_split_b(the_identifier),
-        "complement": split_final(final_s),
+        "first_s": first_split[0],
+        "s_identifier": second_split[0],
+        "complement": second_split[1],
     }
-
     return s_dictionary
-
 
 ## Method implementation that allows users to see requests (tags or commits)
 def see_requests(var_to_show):

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1613,14 +1613,14 @@ def versions_data_iter(repository, revlist=None,
             ## Finally storing the commit in the matching section
 
             sections[matched_section].append({
-                # Add the id and date to use in the code output.
+                ## Add the id and date to use in the code output.
                 "id": commit.sha1_short,
                 "date": commit.author_date,
                 "author": commit.author_name,
-                "authors": commit.author_names,
+                "authors": commit.authors,
                 "subject": subject_process(commit.subject),
                 "body": body_process(commit.body),
-                "commit": commit,
+                "shortRemote": get_url(repository, commit),
             })
 
         ## Flush current version
@@ -1631,6 +1631,20 @@ def versions_data_iter(repository, revlist=None,
             yield current_version
         versions_done[tag] = current_version
 
+## Method that gets the complete url of the commit performed
+def get_url(repository, commit):
+    try:
+        id = commit.sha1_short
+        url = repository.git.config('remote.origin.url')
+        if url:
+            new_url = url[:-4]
+            final_url = new_url + "/commit/" + id
+            return final_url
+        else:
+            return url
+
+    except ValueError:
+        return None
 
 def changelog(output_engine=rest_py,
               unreleased_version_label="unreleased",

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1528,6 +1528,7 @@ def versions_data_iter(repository, revlist=None,
                        subject_process=lambda x: x,
                        log_encoding=DEFAULT_GIT_LOG_ENCODING,
                        warn=warn,        ## Mostly used for test
+                       jira_url="",
                        ):
     """Returns an iterator through versions data structures
 
@@ -1638,6 +1639,8 @@ def versions_data_iter(repository, revlist=None,
                 "first_parameter": t_split["first_s"],
                 "second_parameter": t_split["s_identifier"],
                 "third_parameter": t_split["complement"],
+                "condition_i": t_split["condition_i"],
+                "jira_url": jira_url,
             })
 
         ## Flush current version
@@ -1680,12 +1683,6 @@ def commit_split_b(first_split):
     del(to_split[0])
     final_s = " ".join(to_split)
 
-    '''if the_identifier == "NONE":
-        return the_identifier  ## It should return NONE
-
-    else:
-        return the_identifier  ## It should return url + ANTA...'''
-
     third_split.append(the_identifier)
     third_split.append(final_s)
 
@@ -1696,10 +1693,17 @@ def r_send(commit):
     first_split = commit_split_a(general_split)
     second_split = commit_split_b(first_split)
 
+    if second_split[0] == "NONE" or second_split[0] == "MERGE":
+        condition_i = False
+
+    else:
+        condition_i = True
+
     s_dictionary = {
         "first_s": first_split[0],
         "s_identifier": second_split[0],
         "complement": second_split[1],
+        "condition_i": condition_i,
     }
     return s_dictionary
 
@@ -1850,8 +1854,6 @@ def parse_cmd_line(usage, description, epilog, exname, version):
                         help="Enable debug mode (show full tracebacks).",
                         action="store_true", dest="debug")
     parser.add_argument('revlist', nargs='*', action="store", default=[])
-
-    ##parser.add_argument('-u', '--url', nargs="*", action="")
 
     ## Remove "show" as first argument for compatibility reason.
 
@@ -2089,6 +2091,7 @@ def main():
             body_process=config.get("body_process", noop),
             subject_process=config.get("subject_process", noop),
             log_encoding=log_encoding,
+            jira_url=config["url"],  ## It could work... ¡It worked!
         )
 
         if isinstance(content, basestring):

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -537,7 +537,6 @@ def FileFirstRegexMatch(filename, pattern):
                 die("Named pattern used, but it was not valued.")
             return dct['rev']
         return match.group(0)
-
     return _call
 
 
@@ -834,12 +833,12 @@ class GitCommit(SubGitObjectMixin):
     Authors
     -------
 
-        >>> BODY = ('\\n'
-'        ... Stuff in the body\n'
-'        ... Co-Authored-By: Bob\n'
-'        ... Co-Authored-By: Alice\n'
-'        ... Co-Authored-By: Jack\n'
-'        ... ')
+        >>> BODY = '''\
+        ... Stuff in the body
+        ... Co-Authored-By: Bob
+        ... Co-Authored-By: Alice
+        ... Co-Authored-By: Jack
+        ... '''
 
         >>> head = GitCommit(repos, "HEAD")
         >>> head.author_names
@@ -1186,10 +1185,8 @@ class GitRepos(object):
         No firm reason for that, and it could change in future version.
 
         """
-
         if contains:
             tags = self.git.tag(contains=contains).split("\n")
-
         else:
             tags = self.git.tag().split("\n")
         ## Should we use new version name sorting ?  refering to :

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1634,8 +1634,25 @@ def versions_data_iter(repository, revlist=None,
             ## Finally storing the commit in the matching section
 
 
-            if this_f != -1:
-                pass
+            if this_f:
+                if this_f != -1:
+                    pass
+
+                else:
+                    sections[matched_section].append({
+                        ## Add the id and date to use in the code output.
+                        "id": commit.sha1_short,
+                        "date": commit.date,
+                        "author": commit.author_name,
+                        "authors": commit.authors,
+                        "body": body_process(commit.body),
+                        "shortRemote": get_url(repository, commit),
+                        "first_parameter": t_split["first_s"],
+                        "second_parameter": t_split["s_identifier"],
+                        "third_parameter": t_split["complement"],
+                        "condition_i": t_split["condition_i"],
+                        "jira_url": jira_url,
+                    })
 
             else:
                 sections[matched_section].append({
@@ -1703,6 +1720,7 @@ def r_send(commit):
     general_split = (commit.subject)
     first_split = commit_split_a(general_split)
     second_split = commit_split_b(first_split)
+    to_change = find_remplace(second_split)
 
     if re.search(r"^[A-Za-z].*[\d]+$", second_split[0]):
         condition_i = True
@@ -1771,6 +1789,20 @@ def get_parameters(opts):
 
     else:
         return None
+
+## Incompleted method
+def find_remplace(second_split):
+    complement = second_split[1]
+    print(second_split[0])
+
+    if re.search(r"^[A-Za-z].*[\d]+$", second_split[1]):
+        final_r = complement.replace(second_split[1], "www.google.com/"+second_split[1])
+
+        print(final_r)
+
+    else:
+        print("No se han encontrado coincidencias")
+
 
 def changelog(output_engine=rest_py,
               unreleased_version_label="unreleased",

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1731,11 +1731,12 @@ def find_replace(second_split, jira_url):
         find = re.search(r"^[A-Z]*[\W-][\d]+$", value)
 
         if find:
-            _new_ = str(second_split[1]).replace(value, url)
             parsed = pystache.parse(
-                u"{{#render}}[{{value}}]({{{url}}}/{{{.}}}){{/render}}")
-            to_render = renderer.render(parsed, {'render': _new_})
-            return to_render
+                u"{{#render}}[{{{.}}}]({{#link}}{{.}}{{/link}}/{{{.}}}){{/render}}")
+            to_render = renderer.render(parsed, {'render': value, 'link': url })
+            _new_ = str(second_split[1]).replace(value, to_render)
+
+            return _new_
 
         else:
             _new_ = " ".join(complement)

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1632,7 +1632,7 @@ def versions_data_iter(repository, revlist=None,
         for commit in commits:
 
             ## Commit filtering
-            commit_f = commit.subject
+            commit_f = [commit.subject]
 
             if any(re.search(pattern, commit.subject) is not None
                    for pattern in ignore_regexps):
@@ -1644,29 +1644,26 @@ def versions_data_iter(repository, revlist=None,
             ## Finally storing the commit in the matching section
 
             if clean:
-                result = bool
-                for value in clean:
-                    if value in commit_f:
-                        result = True
+                for item in commit_f:
+                    find_c = True
+                    for i in clean:
+                        if i in item:
+                            find_c = False
 
-                    else:
-                        result = False
-
-                if result is False:
-                    sections[matched_section].append({
-                        ## Add the id and date to use in the code output.
-                        "id": commit.sha1_short,
-                        "date": commit.date,
-                        "author": commit.author_name,
-                        "authors": commit.authors,
-                        "body": body_process(commit.body),
-                        "shortRemote": get_url(repository, commit),
-                        "first_parameter": t_split["first_s"],
-                        "second_parameter": t_split["s_identifier"],
-                        "third_parameter": t_split["complement"],
-                        "condition_i": t_split["condition_i"],
-                        "jira_url": jira_url,
-                    })
+                    if find_c:
+                        sections[matched_section].append({
+                            "id": commit.sha1_short,
+                            "date": commit.date,
+                            "author": commit.author_name,
+                            "authors": commit.authors,
+                            "body": body_process(commit.body),
+                            "shortRemote": get_url(repository, commit),
+                            "first_parameter": t_split["first_s"],
+                            "second_parameter": t_split["s_identifier"],
+                            "third_parameter": t_split["complement"],
+                            "condition_i": t_split["condition_i"],
+                            "jira_url": jira_url,
+                        })
 
             else:
                 sections[matched_section].append({

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1834,6 +1834,9 @@ def change_title(opts):
             new_title = opts.title
             return " ".join(new_title)
 
+        elif opts.title is []:
+            return "Changelog"
+
         else:
             return "Changelog"
 

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -102,7 +102,6 @@ if WIN32 and not PY3:
             ("hStdOutput",      HANDLE), ("hStdError",     HANDLE),
         ]
 
-
     LPSTARTUPINFOW = ctypes.POINTER(STARTUPINFOW)
 
 
@@ -111,7 +110,6 @@ if WIN32 and not PY3:
             ("hProcess",         HANDLE), ("hThread",          HANDLE),
             ("dwProcessId",      DWORD),  ("dwThreadId",       DWORD),
         ]
-
 
     LPPROCESS_INFORMATION = ctypes.POINTER(PROCESS_INFORMATION)
 
@@ -143,7 +141,6 @@ if WIN32 and not PY3:
     ##
     ## Patched functions/classes
     ##
-
 
     def CreateProcess(executable, args, _p_attr, _t_attr,
                       inherit_handles, creation_flags, env, cwd,
@@ -465,7 +462,6 @@ def paragraph_wrap(text, regexp="\n\n"):
 def curryfy(f):
     return lambda *a, **kw: TextProc(lambda txt: f(txt, *a, **kw))
 
-
 ## these are curryfied version of their lower case definition
 
 Indent = curryfy(indent)
@@ -478,7 +474,6 @@ SetIfEmpty = curryfy(set_if_empty)
 for _label in ("Indent", "Wrap", "ReSub", "noop", "final_dot",
               "ucfirst", "strip", "SetIfEmpty"):
     _config_env[_label] = locals()[_label]
-
 
 ##
 ## File
@@ -550,10 +545,7 @@ def FileFirstRegexMatch(filename, pattern):
 def Caret(l):
     def _call():
         return "^%s" % eval_if_callable(l)
-
     return _call
-
-
 ##
 ## System functions
 ##
@@ -807,11 +799,11 @@ class GitCommit(SubGitObjectMixin):
     ``GitCommit`` offers a simple direct API to trailer values. These
     are like RFC822's header value but are at the end of body:
 
-        >>> BODY = ('\\n'
-'        ... Stuff in the body\n'
-'        ... Change-id: 1234\n'
-'        ... Value-X: Supports multi\n'
-'        ...   line values')
+        >>> BODY = '''\
+        ... Stuff in the body
+        ... Change-id: 1234
+        ... Value-X: Supports multi
+        ...   line values'''
 
         >>> head = GitCommit(repos, "HEAD")
         >>> head.trailer_change_id
@@ -823,12 +815,12 @@ class GitCommit(SubGitObjectMixin):
     Notice how the multi-line value was unindented.
     In case of multiple values, these are concatened in lists:
 
-        >>> BODY = ('\\n'
-'        ... Stuff in the body\n'
-'        ... Co-Authored-By: Bob\n'
-'        ... Co-Authored-By: Alice\n'
-'        ... Co-Authored-By: Jack\n'
-'        ... ')
+        >>> BODY = '''\
+        ... Stuff in the body
+        ... Co-Authored-By: Bob
+        ... Co-Authored-By: Alice
+        ... Co-Authored-By: Jack
+        ... '''
 
         >>> head = GitCommit(repos, "HEAD")
         >>> head.trailer_co_authored_by
@@ -1124,7 +1116,6 @@ class GitCmd(SubGitObjectMixin):
             cli_args.extend(args)
 
             return dir_swrap(['git', label, ] + cli_args, shell=False)
-
         return method
 
 
@@ -1207,7 +1198,6 @@ class GitRepos(object):
         ## git version <2.0
         return sorted([self.commit(tag) for tag in tags if tag != ''],
                       key=lambda x: int(x.committer_date_timestamp))
-
 
     def log(self, includes=["HEAD", ], excludes=[], include_merge=True,
             encoding=_preferred_encoding):
@@ -1369,8 +1359,7 @@ def rest_py(data, opts={}):
 
     for version in data["versions"]:
         if len(version["sections"]) > 0:
-            info = render_version(version) + "\n\n"
-            yield info
+            yield render_version(version) + "\n\n"
 
 
 ## formatter engines
@@ -1432,7 +1421,6 @@ if mako:
 
     mako_env = dict((f.__name__, f) for f in (ucfirst, indent, textwrap,
                                               paragraph_wrap))
-
 
     @available_in_config
     def makotemplate(template_name):
@@ -1531,7 +1519,6 @@ def FileRegexSubst(filename, pattern, replace, flags=0):
 ## Data Structure
 ##
 
-
 def versions_data_iter(repository, revlist=None,
                        ignore_regexps=[],
                        section_regexps=[(None, '')],
@@ -1574,8 +1561,6 @@ def versions_data_iter(repository, revlist=None,
                 if rev.startswith("^")] if revlist else []
 
     revs = repository.git.rev_list(*revlist).split("\n") if revlist else []
-
-
     revs = [rev for rev in revs if rev != ""]
 
     if revlist and not revs:
@@ -1610,7 +1595,6 @@ def versions_data_iter(repository, revlist=None,
     section_order = [k for k, _v in section_regexps]
 
     tags = list(reversed(tags))
-
 
     ## Get the changes between tags (releases)
     for idx, tag in enumerate(tags):
@@ -1889,7 +1873,6 @@ def changelog(title, output_engine=mustache,
         data["versions"] = itertools.chain([first_version], versions)
 
     return output_engine(data=data, opts=opts)
-
 
 ##
 ## Manage obsolete options

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1453,8 +1453,6 @@ else:
 def stdout(content):
     for chunk in content:
         safe_print(chunk)
-
-
 @available_in_config
 def FileInsertAtFirstRegexMatch(filename, pattern, flags=0,
                                 idx=lambda m: m.start()):
@@ -1581,11 +1579,9 @@ def versions_data_iter(repository, revlist=None,
 
         for tag in tags:
             new_tags.append(tag)
-
             if max_rev <= tag:
                 break
         tags = new_tags
-
     else:
         max_rev = tags[-1]
 

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -230,7 +230,8 @@ if WIN32 and not PY3:
 usage_msg = """
   %(exname)s {-h|--help}
   %(exname)s {-v|--version}
-  %(exname)s [--debug|-d] [REVLIST]"""
+  %(exname)s [--debug|-d] [REVLIST]
+  %(exname)s {-c|--clean}"""
 
 description_msg = """\
 Run this command in a git repository to output a formatted changelog
@@ -1527,6 +1528,7 @@ def versions_data_iter(repository, revlist=None,
                        log_encoding=DEFAULT_GIT_LOG_ENCODING,
                        warn=warn,        ## Mostly used for test
                        jira_url="",
+                       clean=None,
                        ):
     """Returns an iterator through versions data structures
 
@@ -1866,6 +1868,9 @@ def parse_cmd_line(usage, description, epilog, exname, version):
                         action="store_true", dest="debug")
     parser.add_argument('revlist', nargs='*', action="store", default=[])
 
+    parser.add_argument('-c', '--clean', nargs="*", help="Requires "
+                        "keywords (Ex. -c Item)", action="store")
+
     ## Remove "show" as first argument for compatibility reason.
 
     argv = []
@@ -1886,6 +1891,14 @@ def parse_cmd_line(usage, description, epilog, exname, version):
 
 eval_if_callable = lambda v: v() if callable(v) else v
 
+def get_clean(opts):
+    if opts.clean:
+        cleaner = opts.clean
+        print(cleaner)
+
+    else:
+        cleaner = opts.clean
+        return cleaner
 
 def get_revision(repository, config, opts):
     if opts.revlist:
@@ -2086,13 +2099,14 @@ def main():
 
     log_encoding = get_log_encoding(repository, config)
     revlist = get_revision(repository, config, opts)
+    clean = get_clean(opts)
     config['unreleased_version_label'] = eval_if_callable(
         config['unreleased_version_label'])
     manage_obsolete_options(config)
 
     try:
         content = changelog(
-            repository=repository, revlist=revlist,
+            repository=repository, revlist=revlist, clean=clean,
             ignore_regexps=config['ignore_regexps'],
             section_regexps=config['section_regexps'],
             unreleased_version_label=config['unreleased_version_label'],

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1732,15 +1732,14 @@ def find_replace(second_split, jira_url):
     parsed = pystache.parse(
         u"{{#render}}[{{{.}}}]({{#link}}{{.}}{{/link}}/{{{.}}}){{/render}}")
 
-    to_render = renderer.render(parsed, {
-        'render': find,
-        'link': url
-    })
+    for value in re.finditer(r'[A-Z]*[\W-][\d]+', complement):
+        to_render = renderer.render(parsed, {
+            'render': value.group(),
+            'link': url
+        })
 
-    for value in find:
-        if find:
-            _new_ = complement.replace(value, to_render)
-            return _new_
+        complement = re.sub(r'[A-Z]*[\W-][\d]+', to_render, complement)
+        return complement
 
     return complement
 

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1577,7 +1577,7 @@ def versions_data_iter(repository, revlist=None,
         new_tags = []
 
         var_to_show = revlist[0].split('..')
-        show_tags(var_to_show)
+        see_requests(var_to_show)
 
         for tag in tags:
             new_tags.append(tag)
@@ -1603,8 +1603,7 @@ def versions_data_iter(repository, revlist=None,
             "tagger_date": tag.tagger_date if tag.has_annotated_tag else None,
             "tag": tag.identifier if tag.identifier != "HEAD" else None,
             "commit": tag,
-            "solicited_commits": get_revs(revs),
-            "solicited_tags": show_tags(var_to_show),
+            "solicited_requests": see_requests(var_to_show),
         }
 
         sections = collections.defaultdict(list)
@@ -1642,37 +1641,22 @@ def versions_data_iter(repository, revlist=None,
             yield current_version
         versions_done[tag] = current_version
 
-## Method implementation that allows to see the requested tags
-def show_tags(var_to_show):
+## Method implementation that allows users to see requests (tags or commits)
+def see_requests(var_to_show):
     try:
 
         if len(var_to_show) == 2:
-            first_tag = var_to_show[0]
-            second_tag = var_to_show[1]
+            first_ = var_to_show[0]
+            second_ = var_to_show[1]
 
-            return "From tag  %s to tag %s." % (first_tag, second_tag)
+            return "Instance review from %s to %s." % (first_, second_)
 
         else:
-            return "No tags requested..."
+            return "No reviews requested..."
 
     except ValueError:
         return None
 
-## Method that gets the id's solicited by users and return the information on the screen.
-def get_revs(revs):
-    try:
-        if revs != []:
-            first_commit = revs[-1]
-            second_commit = revs[0]
-
-            return "ID 1 solicited: %s - ID" \
-                   " 2 solicited: %s." % (first_commit, second_commit)
-
-        else:
-            return "Request for all commits made."
-
-    except ValueError:
-        return None
 
 ## Method that gets the complete url of the commit performed
 def get_url(repository, commit):

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1743,7 +1743,7 @@ def find_replace(second_split, jira_url):
         'render': r'\1 ',
         'link': jira_url
     })
-    to_change = re.sub(r'([A-Z]*[\W-][\d]+)', to_render, complement)
+    to_change = re.sub(r'([A-Z]+-[\d]+)', to_render, complement)
 
     return to_change
 
@@ -1754,7 +1754,7 @@ def r_send(commit, jira_url):
     second_split = commit_split_b(first_split)
     to_change = find_replace(second_split, jira_url)
 
-    if re.search(r"^[A-Z]*[\W-][\d]+$", second_split[0]):
+    if re.search(r"^[A-Z]+-[\d]+$", second_split[0]):
         condition_i = True
 
     else:

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1735,8 +1735,9 @@ def get_url(repository, commit):
             if p_url == "git@":
                 url_r = url.replace(":", "/")
                 this_r = url_r[4:]
+                final_r = this_r[:-4]
                 p_url = "https://"
-                final_url_g = p_url + this_r + "commit/" + id
+                final_url_g = p_url + final_r + "/commit/" + id
                 return final_url_g
 
             else:

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1648,24 +1648,6 @@ def get_url(repository, commit):
     except ValueError:
         return None
 
-def revs_range(*revlist):
-    revs = []
-    try:
-        print("************************************************************")
-        print("************************************************************")
-        print("**                REPORTS BY RANK                         **")
-        print("************************************************************")
-        print("************************************************************")
-        first_commit = str(input("**  Enter the first ID to evaluate: "))
-        revs.append(first_commit)
-        second_commit = str(input("**  Enter the second ID to evaluate: "))
-        revs.append(second_commit)
-        print("************************************************************")
-        print("************************************************************")
-        return revs
-
-    except ValueError:
-        return None
 
 def changelog(output_engine=rest_py,
               unreleased_version_label="unreleased",

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1844,7 +1844,7 @@ def change_title(opts):
         return "Changelog"
 
 
-def changelog(title, output_engine=rest_py,
+def changelog(title, output_engine=mustache,
               unreleased_version_label="unreleased",
               warn=warn,        ## Mostly used for test
               **kwargs):
@@ -2200,7 +2200,7 @@ def main():
             section_regexps=config['section_regexps'],
             unreleased_version_label=config['unreleased_version_label'],
             tag_filter_regexp=config['tag_filter_regexp'],
-            output_engine=config.get("output_engine", rest_py),
+            output_engine=config.get("output_engine", mustache),
             include_merge=config.get("include_merge", True),
             body_process=config.get("body_process", noop),
             subject_process=config.get("subject_process", noop),

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1352,16 +1352,10 @@ def rest_py(data, opts={}):
     if data["title"]:
         yield rest_title(data["title"], char="=") + "\n\n"
 
-    # Save the commits output in a plain text file .md
-    dir_fichero = 'fichero_git.md'
-
-    fichero = open(dir_fichero, 'w')
     for version in data["versions"]:
         if len(version["sections"]) > 0:
             info = render_version(version) + "\n\n"
-            fichero.write(info)
             yield info
-    fichero.close()
 
 
 ## formatter engines
@@ -1596,6 +1590,7 @@ def versions_data_iter(repository, revlist=None,
             "tagger_date": tag.tagger_date if tag.has_annotated_tag else None,
             "tag": tag.identifier if tag.identifier != "HEAD" else None,
             "commit": tag,
+            "solicited_commits": get_revs(revs),
         }
 
         sections = collections.defaultdict(list)
@@ -1632,6 +1627,21 @@ def versions_data_iter(repository, revlist=None,
         if len(current_version["sections"]) != 0:
             yield current_version
         versions_done[tag] = current_version
+
+## Method that gets the id's solicited by users and return the information on the screen.
+def get_revs(revs):
+    try:
+        if revs != []:
+            first_commit = revs[-1]
+            second_commit = revs[0]
+
+            return "ID 1 solicited: %s - ID" \
+                   " 2 solicited: %s." % (first_commit, second_commit)
+
+        else:
+            return "Request for all commits made."
+    except ValueError:
+        return None
 
 ## Method that gets the complete url of the commit performed
 def get_url(repository, commit):

--- a/src/gitchangelog/gitchangelog.rc.reference
+++ b/src/gitchangelog/gitchangelog.rc.reference
@@ -188,7 +188,7 @@ unreleased_version_label = "(unreleased)"
 ##        Examples:
 ##           - makotemplate("restructuredtext")
 ##
-output_engine = rest_py
+#output_engine = rest_py
 #output_engine = mustache("restructuredtext")
 output_engine = mustache("markdown")
 #output_engine = makotemplate("restructuredtext")

--- a/src/gitchangelog/gitchangelog.rc.reference
+++ b/src/gitchangelog/gitchangelog.rc.reference
@@ -289,4 +289,4 @@ include_merge = True
 revs = []
 
 ## ´´url´´ is a string that allows you to concatenate with the Jira url. Important: Change url.
-url = 'https://github.com/gustavo15Rodriguez'
+url = ''

--- a/src/gitchangelog/gitchangelog.rc.reference
+++ b/src/gitchangelog/gitchangelog.rc.reference
@@ -287,3 +287,6 @@ include_merge = True
 #    "HEAD"
 #]
 revs = []
+
+## ´´url´´ is a string that allows you to concatenate with the Jira url. Important: Change url.
+url = 'https://github.com/gustavo15Rodriguez'

--- a/src/gitchangelog/gitchangelog.rc.reference
+++ b/src/gitchangelog/gitchangelog.rc.reference
@@ -190,7 +190,7 @@ unreleased_version_label = "(unreleased)"
 ##
 output_engine = rest_py
 #output_engine = mustache("restructuredtext")
-#output_engine = mustache("markdown")
+output_engine = mustache("markdown")
 #output_engine = makotemplate("restructuredtext")
 
 

--- a/src/gitchangelog/gitchangelog.rc.reference.v2.1.3
+++ b/src/gitchangelog/gitchangelog.rc.reference.v2.1.3
@@ -154,9 +154,9 @@ unreleased_version_label = "(unreleased)"
 ##        Examples:
 ##           - makotemplate("restructuredtext")
 ##
-output_engine = rest_py
+#output_engine = rest_py
 #output_engine = mustache("restructuredtext")
-#output_engine = mustache("markdown")
+output_engine = mustache("markdown")
 #output_engine = makotemplate("restructuredtext")
 
 

--- a/src/gitchangelog/templates/mustache/markdown.tpl
+++ b/src/gitchangelog/templates/mustache/markdown.tpl
@@ -10,10 +10,12 @@
 ### {{{label}}}
 
 {{#commits}}
-ID: {{{id}}}
-Fecha: {{{date}}}
-Commit: {{{subject}}}
-Autor: {{{author}}}
+* **ID:** [{{{id}}}]({{{shortRemote}}})
+* **Fecha:** {{{date}}}
+* **Commit:** {{{subject}}}
+* **Autor:** {{#authors}}{{{.}}}{{/authors}}
+
+
 {{#body}}
 
 {{{body_indented}}}

--- a/src/gitchangelog/templates/mustache/markdown.tpl
+++ b/src/gitchangelog/templates/mustache/markdown.tpl
@@ -1,6 +1,7 @@
 {{#general_title}}
 # {{{title}}}
 
+
 {{/general_title}}
 
 {{#versions}}
@@ -11,7 +12,8 @@
 {{#sections}}
 
 {{#commits}}
-* [{{{id}}}]({{{shortRemote}}}) - *{{{date}}}* - **{{{first_parameter}}}***{{{second_parameter}}}*m{{{third_parameter}}} - {{#body}}{{{body_indented}}}{{/body}} - **{{#authors}}{{{.}}}{{/authors}}**
+* [{{{id}}}]({{{shortRemote}}}) - *{{{date}}}* - **{{{first_parameter}}}**
+*{{#condition_i}}[{{{second_parameter}}}]({{{jira_url}}}/{{{second_parameter}}}){{/condition_i}}{{^condition_i}}{{{second_parameter}}}{{/condition_i}}* {{{third_parameter}}}- {{#body}}{{{body_indented}}}{{/body}} - **{{#authors}}{{{.}}}{{/authors}}**
 
 
 {{/commits}}

--- a/src/gitchangelog/templates/mustache/markdown.tpl
+++ b/src/gitchangelog/templates/mustache/markdown.tpl
@@ -11,7 +11,7 @@
 {{#sections}}
 
 {{#commits}}
-* [{{{id}}}]({{{shortRemote}}}) - *{{{date}}}* - {{{subject}}} - {{#body}}{{{body_indented}}}{{/body}} - **{{#authors}}{{{.}}}{{/authors}}**
+* [{{{id}}}]({{{shortRemote}}}) - *{{{date}}}* - **{{{first_parameter}}}***{{{second_parameter}}}*m{{{third_parameter}}} - {{#body}}{{{body_indented}}}{{/body}} - **{{#authors}}{{{.}}}{{/authors}}**
 
 
 {{/commits}}

--- a/src/gitchangelog/templates/mustache/markdown.tpl
+++ b/src/gitchangelog/templates/mustache/markdown.tpl
@@ -10,16 +10,8 @@
 ### {{{label}}}
 
 {{#commits}}
-* **ID:** [{{{id}}}]({{{shortRemote}}})
-* **Fecha:** {{{date}}}
-* **Commit:** {{{subject}}}
-* **Autor:** {{#authors}}{{{.}}}{{/authors}}
-
-
-{{#body}}
-
-{{{body_indented}}}
-{{/body}}
+* [{{{id}}}]({{{shortRemote}}}) - {{{subject}}} - {{#authors}}{{{.}}}{{/authors}} - {{{date}}}
+  {{#body}}{{{body_indented}}}{{/body}}
 
 {{/commits}}
 {{/sections}}

--- a/src/gitchangelog/templates/mustache/markdown.tpl
+++ b/src/gitchangelog/templates/mustache/markdown.tpl
@@ -5,8 +5,6 @@
 {{/general_title}}
 
 {{#versions}}
-## Commits description
-
 ### {{{solicited_requests}}}
 
 {{#sections}}

--- a/src/gitchangelog/templates/mustache/markdown.tpl
+++ b/src/gitchangelog/templates/mustache/markdown.tpl
@@ -11,7 +11,7 @@
 {{#sections}}
 
 {{#commits}}
-* [{{{id}}}]({{{shortRemote}}}) - {{{date}}} - {{{subject}}} - {{#body}}{{{body_indented}}}{{/body}} - {{#authors}}{{{.}}}{{/authors}}
+* [{{{id}}}]({{{shortRemote}}}) - *{{{date}}}* - {{{subject}}} - {{#body}}{{{body_indented}}}{{/body}} - **{{#authors}}{{{.}}}{{/authors}}**
 
 
 {{/commits}}

--- a/src/gitchangelog/templates/mustache/markdown.tpl
+++ b/src/gitchangelog/templates/mustache/markdown.tpl
@@ -10,7 +10,10 @@
 ### {{{label}}}
 
 {{#commits}}
-* {{{subject}}} [{{{author}}}]
+ID: {{{id}}}
+Fecha: {{{date}}}
+Commit: {{{subject}}}
+Autor: {{{author}}}
 {{#body}}
 
 {{{body_indented}}}

--- a/src/gitchangelog/templates/mustache/markdown.tpl
+++ b/src/gitchangelog/templates/mustache/markdown.tpl
@@ -12,8 +12,8 @@
 {{#sections}}
 
 {{#commits}}
-* [{{{id}}}]({{{shortRemote}}}) - *{{{date}}}* - **{{{first_parameter}}}**
-*{{#condition_i}}[{{{second_parameter}}}]({{{jira_url}}}/{{{second_parameter}}}){{/condition_i}}{{^condition_i}}{{{second_parameter}}}{{/condition_i}}* {{{third_parameter}}}- {{#body}}{{{body_indented}}}{{/body}} - **{{#authors}}{{{.}}}{{/authors}}**
+* [{{{id}}}]({{{shortRemote}}}) - *{{{date}}}* - **{{{first_parameter}}}
+{{#condition_i}}[{{{second_parameter}}}]({{{jira_url}}}/{{{second_parameter}}}){{/condition_i}}{{^condition_i}}{{{second_parameter}}}{{/condition_i}}** {{{third_parameter}}}- {{#body}}{{{body_indented}}}{{/body}} - **{{#authors}}{{{.}}}{{/authors}}**
 
 
 {{/commits}}

--- a/src/gitchangelog/templates/mustache/markdown.tpl
+++ b/src/gitchangelog/templates/mustache/markdown.tpl
@@ -12,8 +12,8 @@
 {{#sections}}
 
 {{#commits}}
-* [{{{id}}}]({{{shortRemote}}}) - *{{{date}}}* - **{{{first_parameter}}}
-{{#condition_i}}[{{{second_parameter}}}]({{{jira_url}}}/{{{second_parameter}}}){{/condition_i}}{{^condition_i}}{{{second_parameter}}}{{/condition_i}}** {{{third_parameter}}}- {{#body}}{{{body_indented}}}{{/body}} - **{{#authors}}{{{.}}}{{/authors}}**
+* [{{{id}}}]({{{shortRemote}}}) - *{{{date}}}* -
+{{#condition_i}}**{{{first_parameter}}}[{{{second_parameter}}}]({{{jira_url}}}/{{{second_parameter}}})**{{/condition_i}}{{^condition_i}}**{{{first_parameter}}}{{{second_parameter}}}**{{/condition_i}} {{{third_parameter}}} - {{#body}}{{{body_indented}}}{{/body}} - **{{#authors}}{{{.}}}{{/authors}}**
 
 
 {{/commits}}

--- a/src/gitchangelog/templates/mustache/markdown.tpl
+++ b/src/gitchangelog/templates/mustache/markdown.tpl
@@ -10,8 +10,8 @@
 ### {{{label}}}
 
 {{#commits}}
-* [{{{id}}}]({{{shortRemote}}}) - {{{subject}}} - {{#authors}}{{{.}}}{{/authors}} - {{{date}}}
-  {{#body}}{{{body_indented}}}{{/body}}
+* [{{{id}}}]({{{shortRemote}}}) - {{{date}}} - {{{subject}}} - {{#body}}{{{body_indented}}}{{/body}} - {{#authors}}{{{.}}}{{/authors}}
+
 
 {{/commits}}
 {{/sections}}

--- a/src/gitchangelog/templates/mustache/markdown.tpl
+++ b/src/gitchangelog/templates/mustache/markdown.tpl
@@ -1,13 +1,14 @@
 {{#general_title}}
 # {{{title}}}
 
-
 {{/general_title}}
+
 {{#versions}}
-## {{{label}}}
+## Commits description
+
+#### {{{solicited_commits}}}
 
 {{#sections}}
-### {{{label}}}
 
 {{#commits}}
 * [{{{id}}}]({{{shortRemote}}}) - {{{date}}} - {{{subject}}} - {{#body}}{{{body_indented}}}{{/body}} - {{#authors}}{{{.}}}{{/authors}}

--- a/src/gitchangelog/templates/mustache/markdown.tpl
+++ b/src/gitchangelog/templates/mustache/markdown.tpl
@@ -6,6 +6,8 @@
 {{#versions}}
 ## Commits description
 
+### {{{solicited_tags}}}
+
 #### {{{solicited_commits}}}
 
 {{#sections}}

--- a/src/gitchangelog/templates/mustache/markdown.tpl
+++ b/src/gitchangelog/templates/mustache/markdown.tpl
@@ -6,9 +6,7 @@
 {{#versions}}
 ## Commits description
 
-### {{{solicited_tags}}}
-
-#### {{{solicited_commits}}}
+### {{{solicited_requests}}}
 
 {{#sections}}
 


### PR DESCRIPTION
Ahora se puede agregar un titulo al changelog especificando "gitchangelog.py --title "Nombre deseado"", también permite filtrar todos aquellos commits que no se deseen, escribiendo una palabra implícita en dichos commits, es decir, "gitchangelog.py --clean templates Agregando"... y así sucesivamente, separando las palabras por espacios.

Se ha añadido un archivo .txt llamado requirements, que lo que permite es instalar aquellas librerías o dependencias que se necesitan cuando se descarga el changelog por primera vez. Se ejecuta utilizando el comando "pip install -r requirements.txt" ubicándonos en la ruta de dicho documento.

Se pueden utilizar todos los comando una sola vez, solo basta con especificar si es --title parámetros --clean parámetros.

Ahora se utiliza la plantilla de mustache por defecto.